### PR TITLE
88_Timer.pm: sub Timer_Check - readingsSingleUpdate

### DIFF
--- a/FHEM/88_Timer.pm
+++ b/FHEM/88_Timer.pm
@@ -907,7 +907,8 @@ sub Timer_Check($) {
 				if ($set == 1) {
 					Log3 $name, 4, "$name: $d - set $values[6] $values[7] ($dayOfWeek, $values[0]-$values[1]-$values[2] $values[3]:$values[4]:$values[5])";
 					CommandSet($hash, $values[6]." ".$values[7]) if ($values[7] ne "DEF");
-					$state = "$d set $values[6] $values[7] accomplished";
+					# $state = "$d set $values[6] $values[7] accomplished";
+					readingsSingleUpdate($hash, "state" , "$d set $values[6] $values[7] accomplished", 1);
 					if ($values[7] eq "DEF") {
 						if (AttrVal($name, $d."_set", undef)) {
 							Log3 $name, 5, "$name: $d - exec at command: ".AttrVal($name, $d."_set", undef);


### PR DESCRIPTION
Bei mehreren Timern und gleicher Startzeit wurde nur ein Logeintrag geschreiben und nur ein Event ausgelöst.
Mit diesem Patch werden werden alle Events erfasst:
2020-01-02_16:07:00.033 Timer Timer_13 set FS10_5_13 on accomplished
2020-01-02_16:07:00.064 Timer Timer_16 set FS10_6_11 on accomplished
2020-01-02_16:07:00.089 Timer Timer_04 set FS10_2_13 on accomplished
2020-01-02_16:07:00.113 Timer Timer_08 set FS10_3_14 on accomplished
